### PR TITLE
Fix code scanning alert no. 16: Database query built from user-controlled sources

### DIFF
--- a/vulnerability/sqli/function.go
+++ b/vulnerability/sqli/function.go
@@ -34,11 +34,17 @@ func (p *Profile) UnsafeQueryGetData(uid string) error {
 	/* this funciton use to get data Profile from database with vulnerable query */
 	DB, err = database.Connect()
 
-	getProfileSql := fmt.Sprintf(`SELECT p.user_id, p.full_name, p.city, p.phone_number 
-								FROM Profile as p,Users as u 
-								where p.user_id = u.id 
-								and u.id=%s`, uid) //here is the vulnerable query
-	rows, err := DB.Query(getProfileSql)
+	const getProfileSql = `SELECT p.user_id, p.full_name, p.city, p.phone_number 
+							FROM Profile as p, Users as u 
+							WHERE p.user_id = u.id 
+							AND u.id = ?`
+	stmt, err := DB.Prepare(getProfileSql)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	rows, err := stmt.Query(uid)
 	if err != nil {
 		return err //this will return error query to clien hmmmm.
 	}


### PR DESCRIPTION
Fixes [https://github.com/xeonproc/govwa/security/code-scanning/16](https://github.com/xeonproc/govwa/security/code-scanning/16)

To fix the problem, we should replace the vulnerable query construction using `fmt.Sprintf` with a parameterized query using prepared statements. This approach ensures that user-provided data is safely embedded into the query, preventing SQL injection attacks.

1. Replace the `fmt.Sprintf` query construction with a parameterized query.
2. Use the `DB.Prepare` method to create a prepared statement.
3. Execute the prepared statement with the user-provided `uid` as a parameter.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
