### PR TITLE
Fix code scanning alert no. 14: Unsafe jQuery plugin

### DIFF
--- a/public/js/bootstrap.js
+++ b/public/js/bootstrap.js
@@ -1996,7 +1996,7 @@ if (typeof jQuery === 'undefined') {
       '[data-target="' + target + '"],' +
       this.selector + '[href="' + target + '"]'
 
-    var active = $(selector)
+    var active = $.find(selector)
       .parents('li')
       .addClass('active')
 
@@ -2010,7 +2010,7 @@ if (typeof jQuery === 'undefined') {
   }
 
   ScrollSpy.prototype.clear = function () {
-    $(this.selector)
+    $.find(this.selector)
       .parentsUntil(this.options.target, '.active')
       .removeClass('active')
   }


### PR DESCRIPTION
Fixes [https://github.com/xeonproc/govwa/security/code-scanning/14](https://github.com/xeonproc/govwa/security/code-scanning/14)

To fix the problem, we need to ensure that the `this.selector` is always treated as a CSS selector and not as HTML. This can be achieved by using jQuery's `find` method instead of directly using the jQuery constructor with a potentially unsafe string. This change will prevent the interpretation of the string as HTML.

- **General Fix:** Use `jQuery.find` to interpret `this.selector` as a CSS selector.
- **Detailed Fix:** Modify the `ScrollSpy.prototype.clear` and `ScrollSpy.prototype.activate` methods to use `jQuery.find` instead of `$(this.selector)`.
- **Files/Regions/Lines to Change:** The changes will be made in `public/js/bootstrap.js` around lines 1999 and 2013.
- **Needed Changes:** No new methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
